### PR TITLE
add required env variable - container_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,8 @@ services:
       context: .
       target: sibling-container
     container_name: prometheus-wireguard-exporter
-    # environment:
+    environment:
+      - PROMETHEUS_WIREGUARD_EXPORTER_CONTAINER_NAME=wireguard # required: name of wireguard service/container
     #   - PROMETHEUS_WIREGUARD_EXPORTER_CONFIG_FILE_NAMES=/etc/wg0.conf # optional
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro # allow access to host docker from the container


### PR DESCRIPTION
`docker exec` within **prometheus-wireguard-exporter** expects the name of the container where wireguard is running

The `PROMETHEUS_WIREGUARD_EXPORTER_CONTAINER_NAME` parameter/flag is not documented https://github.com/aroglahcim/prometheus-wireguard-exporter?tab=readme-ov-file#usage

ref:
https://github.com/aroglahcim/prometheus-wireguard-exporter/blob/3cd27ecbe1266a7924e3c19791b12ab9c94376a8/src/main.rs#L55-L64